### PR TITLE
Add winrate based balance option

### DIFF
--- a/src/components/BD/Balance.vue
+++ b/src/components/BD/Balance.vue
@@ -4,20 +4,26 @@
       <div style="font-size: 14px; color: #4d749e; font-style: italic; float: right; margin: 5px">Attempt to balance out the selected types for each side</div>
       <div style="font-size: 30px; margin-bottom: 5px">Balance</div>
       <div style="font-size: 14px; color: rgba(255, 255, 255, 0.5)">
-        <div style="display: flex; padding: 0 1%">
-          <div style="flex: 1; margin: 0 1%">
-            <p>Primary Attribute</p>
-            <div style="padding: 2px">
-              <Toggle v-model="balanceAttribute" class="toggle-purple" />
-            </div>
+          <div style="display: flex; padding: 0 1%">
+              <div style="flex: 1; margin: 0 1%">
+                  <p>Primary Attribute</p>
+                  <div style="padding: 2px">
+                      <Toggle v-model="balanceAttribute" class="toggle-purple" />
+                  </div>
+              </div>
+              <div style="flex: 1; margin: 0 1%">
+                  <p>Attack Capabilities</p>
+                  <div style="padding: 2px">
+                      <Toggle v-model="balanceCapabilities" class="toggle-purple" />
+                  </div>
+              </div>
+              <div style="flex: 1; margin: 0 1%">
+                  <p>Balance (Urist's Algorithm)</p>
+                  <div style="padding: 2px">
+                      <Toggle v-model="balanceUrist" class="toggle-purple" />
+                  </div>
+              </div>
           </div>
-          <div style="flex: 1; margin: 0 1%">
-            <p>Attack Capabilities</p>
-            <div style="padding: 2px">
-              <Toggle v-model="balanceCapabilities" class="toggle-purple" />
-            </div>
-          </div>
-        </div>
       </div>
     </div>
   </div>
@@ -48,6 +54,14 @@ export default {
       },
       set(value) {
         this.$store.commit('bd/set', { key: 'balanceCapabilities', value: value })
+      },
+      },
+    balanceUrist: {
+      get() {
+        return this.$store.state.bd.balanceUrist
+      },
+      set(value) {
+        this.$store.commit('bd/set', { key: 'balanceUrist', value: value })
       },
     },
   },

--- a/src/store/BD/index.js
+++ b/src/store/BD/index.js
@@ -1,5 +1,5 @@
 import db from '@/assets/heroes.json'
-import { shuffleArray } from '@/store/shuffle'
+import { shuffleArray, balanceByWinrate } from '@/store/shuffle'
 
 var groupBy = function (xs, key) {
   return xs.reduce(function (rv, x) {
@@ -33,6 +33,7 @@ export const BalancedDraft = {
       // Balance
       balanceAttribute: false,
       balanceCapabilities: false,
+      balanceUrist: false,
       // Order
       sequence: 0,
       // Additional Options
@@ -170,6 +171,10 @@ export const BalancedDraft = {
         } else {
           break
         }
+      }
+      if (state.balanceUrist) {
+        console.log("Pre-balance roster:" + roster.map(a => a.hero.name));
+        roster = balanceByWinrate(roster)
       }
 
       let heroes = roster

--- a/src/store/BD/index.js
+++ b/src/store/BD/index.js
@@ -1,5 +1,5 @@
 import db from '@/assets/heroes.json'
-import { shuffleArray, balanceByWinrate } from '@/store/shuffle'
+import { shuffleArray, balanceByWinrate, matchedSort } from '@/store/shuffle'
 
 var groupBy = function (xs, key) {
   return xs.reduce(function (rv, x) {
@@ -176,7 +176,7 @@ export const BalancedDraft = {
         roster = balanceByWinrate(roster)
       }
 
-      let heroes = roster
+      let heroes = (state.sequence == 3 ? matchedSort(roster) : roster)
         .sort((lhs, rhs) => {
           let result = lhs.team - rhs.team
           if (result == 0) {
@@ -212,6 +212,7 @@ export const BalancedDraft = {
         { value: 0, label: 'Random' },
         { value: 1, label: 'Weaker Heroes First' },
         { value: 2, label: 'Stronger Heroes First' },
+        { value: 3, label: 'Matched' },
       ]
     },
     commands: (state) => {

--- a/src/store/BD/index.js
+++ b/src/store/BD/index.js
@@ -173,7 +173,6 @@ export const BalancedDraft = {
         }
       }
       if (state.balanceUrist) {
-        console.log("Pre-balance roster:" + roster.map(a => a.hero.name));
         roster = balanceByWinrate(roster)
       }
 

--- a/src/store/shuffle.js
+++ b/src/store/shuffle.js
@@ -16,20 +16,24 @@ export function shuffleArray(array) {
 }
 
 export function matchedSort(roster) {
-  const rad = roster.slice(0, 5);
-  const wrOrder = rad.map((a, i) => ({ id: i, winrate: a.hero?.win_rate }))
+  const rad = roster.filter(a=>a.team == 1);
+  const wrOrderRad = rad.map((a, i) => ({ id: i, winrate: a.hero?.win_rate }))
     .sort((lhs, rhs) => lhs.winrate - rhs.winrate)
     .map((a, i) => ({ id: a.id, winrate: a.winrate, wrOrder: i }))
     .sort((lhs, rhs) => lhs.id - rhs.id);
-
-  const dire = wrOrder.map(a => roster[a.wrOrder + 5]);
-  return [...rad,...dire, roster[10], roster[11]];
+  const wrOrderDire = roster.filter(a=>a.team == 2).sort((lhs, rhs) => lhs.hero?.win_rate - rhs.hero?.win_rate);
+  const dire = wrOrderRad.map(a => wrOrderDire[a.wrOrder]);
+  console.log("Matched Order:");
+  console.log([...rad, ...dire, roster.filter(a=>a.team == 3)]);
+  return [...rad, ...dire, ...roster.filter(a => a.team == 3)];
 }
 
 export function balanceByWinrate(roster) {
   console.log("begin rebalance");
-  const combs = [0, 1, 2, 3, 4].map((a) => [roster[a], roster[a+5]])
-  var balancedRosterPairs = combinator(combs, winrateDifference, [roster[10], roster[11]]).roster;
+  const rad = roster.filter(a => a.team == 1);
+  const dire = roster.filter(a => a.team == 2);
+  const combs = [0, 1, 2, 3, 4].map((a) => [rad[a], dire[a]])
+  var balancedRosterPairs = combinator(combs, winrateDifference, [...roster.filter(a => a.team == 3)]).roster;
   var nonReserve = [...balancedRosterPairs.map(a => { a[0].team = 1; return a[0] }), ...balancedRosterPairs.map(a => { a[1].team = 2; return a[1] })];
   var reserve = roster.filter(a => nonReserve.map(r => r.hero.id).indexOf(a.hero.id) < 0);
   reserve.forEach(a => a.team = 3);
@@ -44,7 +48,7 @@ function combinator(list, compFunction, adds, n = 0, used = [], current = [], be
       best.roster = current;
       best.min = comparisonResult;
       console.log("found better:" + current.map(a => a[0].hero.name + " vs " + a[1].hero.name));
-      console.log("new imbalance:" + (100 * best.min).toFixed(1));
+      console.log("new imbalance:" + (1000 * best.min).toFixed(1));
     }
   }
   else

--- a/src/store/shuffle.js
+++ b/src/store/shuffle.js
@@ -14,3 +14,45 @@ export function shuffleArray(array) {
 
   return array
 }
+
+export function balanceByWinrate(roster) {
+  const combs = [0, 1, 2, 3, 4].map((a) => [roster[a], roster[a+5]])
+
+  var balancedRosterPairs = combinator(combs, winrateDifference, [roster[10], roster[11]]).roster;
+  var nonReserve = [...balancedRosterPairs.map(a => { a[0].team = 1; return a[0] }), ...balancedRosterPairs.map(a => { a[1].team = 2; return a[1] })];
+  var reserve = roster.filter(a => nonReserve.map(r => r.hero.id).indexOf(a.hero.id) < 0);
+  reserve.forEach(a => a.team = 3);
+  var newRoster = [...nonReserve, ...reserve ];
+  return newRoster;
+}
+
+function combinator(list, compFunction, adds, n = 0, used = [], current = [], best = {roster:[], min:1000}, ) {
+  if (n === list.length) {
+    const comparisonResult = compFunction(current);
+    if (comparisonResult < best.min) {
+      best.roster = current;
+      best.min = comparisonResult;
+      console.log("found better:" + current.map(a => a[0].hero.name + " vs " + a[1].hero.name));
+      console.log("new imbalance:" + (100 * best.min).toFixed(1));
+    }
+  }
+  else
+  {
+    var vals = [...list[n], ...adds.filter((a) => !used[a.hero.id])];
+    var addCombinations = vals.flatMap((a) => vals.filter(b=>a!=b).map(b => [a, b]));
+    addCombinations.forEach(item => {
+      var newUsed = [...used];
+      newUsed[item[0].hero.id] = 1;
+      newUsed[item[1].hero.id] = 1;
+      combinator(list, compFunction, adds, n + 1, newUsed, [...current, item], best)
+    });
+  }
+
+  return best;
+}
+
+function winrateDifference(roster) {
+  const radiantWin = roster.reduce((c, a) => c + a[0].hero.win_rate, 0);
+  const direWin = roster.reduce((c, a) => c + a[1].hero.win_rate, 0);
+  return Math.abs(radiantWin - direWin);
+}

--- a/src/store/shuffle.js
+++ b/src/store/shuffle.js
@@ -15,6 +15,17 @@ export function shuffleArray(array) {
   return array
 }
 
+export function matchedSort(roster) {
+  const rad = roster.slice(0, 5);
+  const wrOrder = rad.map((a, i) => ({ id: i, winrate: a.hero?.win_rate }))
+    .sort((lhs, rhs) => lhs.winrate - rhs.winrate)
+    .map((a, i) => ({ id: a.id, winrate: a.winrate, wrOrder: i }))
+    .sort((lhs, rhs) => lhs.id - rhs.id);
+
+  const dire = wrOrder.map(a => roster[a.wrOrder + 5]);
+  return [...rad,...dire, roster[10], roster[11]];
+}
+
 export function balanceByWinrate(roster) {
   console.log("begin rebalance");
   const combs = [0, 1, 2, 3, 4].map((a) => [roster[a], roster[a+5]])

--- a/src/store/shuffle.js
+++ b/src/store/shuffle.js
@@ -16,8 +16,8 @@ export function shuffleArray(array) {
 }
 
 export function balanceByWinrate(roster) {
+  console.log("begin rebalance");
   const combs = [0, 1, 2, 3, 4].map((a) => [roster[a], roster[a+5]])
-
   var balancedRosterPairs = combinator(combs, winrateDifference, [roster[10], roster[11]]).roster;
   var nonReserve = [...balancedRosterPairs.map(a => { a[0].team = 1; return a[0] }), ...balancedRosterPairs.map(a => { a[1].team = 2; return a[1] })];
   var reserve = roster.filter(a => nonReserve.map(r => r.hero.id).indexOf(a.hero.id) < 0);


### PR DESCRIPTION
### Objective:
Give drafting options that would provide more fair and tournament worthy pools without removing "fun" : doesn't necessitate the removal of models or skills, allow existing BD restrictions

### Balance by winrate.
-This produces balanced rosters without excluding any models. 
-This shuffles the reserve models and slots pairs (eg. for slot 1: all combinations dire 1, radiant 1, reserve 1 reserve 2) into each player slot and uses hungarian algorithm to find the roster with the lowest imbalance.
-This does have a slight bias to benching the outliers, because it's mathematically less likely to find the most balanced combination with them, but this is minor and still frequently includes them.

### Matched sorting
-We find that even with balanced rosters a large imbalance comes from pick order and existing sort options (win first, loss first) prescribe too much.
-This matches the winrate order of the two teams. 
eg. In this balanced draft:
Radiant
{id: 0, winrate: '0.59'}
{id: 1, winrate: '0.54'}
{id: 2, winrate: '0.47'}
{id: 3, winrate: '0.50'}
{id: 4, winrate: '0.48'}
Dire
{id: 0, winrate: '0.49'}
{id: 1, winrate: '0.46'}
{id: 2, winrate: '0.53'}
{id: 3, winrate: '0.54'}
{id: 4, winrate: '0.55'}

Dire has a disadvantage due to first pick being gyro (0.59) v sven (0.49)
The match sort will rearrange Dire to approximate the Radiant winrate order:
{id: 0, winrate: '0.55'}
{id: 1, winrate: '0.54'}
{id: 2, winrate: '0.46'}
{id: 3, winrate: '0.53'}
{id: 4, winrate: '0.49'}

